### PR TITLE
remove proxy setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,14 +101,6 @@ iface wlp2s0 inet dhcp
 
 `ifup wlp2s0` というコマンドでインターフェースが立ち上がる。
 
-### プロキシの設定
-
-```bash
-export http_proxy=http://proxy.ksc.kwansei.ac.jp:8080
-export https_proxy=http://proxy.ksc.kwansei.ac.jp:8080
-export ftp_proxy=http://proxy.ksc.kwansei.ac.jp:8080
-```
-
 ### 必須アプリケーションのインストール
 
 ```bash


### PR DESCRIPTION
学内ネットワーク機器リプレースに伴い、プロキシが不要になりました。

そのため、設定のドキュメントからプロキシに関する記述を削除しました。